### PR TITLE
Fix unlogin issue when connecting with same username

### DIFF
--- a/velocity/src/main/java/me/adrianed/authmevelocity/velocity/listener/ProxyListener.java
+++ b/velocity/src/main/java/me/adrianed/authmevelocity/velocity/listener/ProxyListener.java
@@ -24,6 +24,10 @@ public final class ProxyListener {
 
     @Subscribe
     public EventTask onDisconnect(final DisconnectEvent event) {
+        if (event.getLoginStatus() == DisconnectEvent.LoginStatus.CONFLICTING_LOGIN) {
+            return EventTask.async(() -> {});
+        }
+
         return EventTask.async(() -> plugin.removePlayer(event.getPlayer()));
     }
 
@@ -76,7 +80,7 @@ public final class ProxyListener {
         if (canBeIgnored(event.getPlayer())) {
             plugin.logDebug("PlayerChatEvent | Ignored signed player");
             continuation.resume();
-            return; 
+            return;
         }
 
         event.setResult(PlayerChatEvent.ChatResult.denied());
@@ -113,5 +117,5 @@ public final class ProxyListener {
             && player.getProtocolVersion().compareTo(ProtocolVersion.MINECRAFT_1_19_1) >= 0
             && plugin.config().get().advanced().ignoreSignedPlayers();
     }
-    
+
 }

--- a/velocity/src/main/java/me/adrianed/authmevelocity/velocity/listener/ProxyListener.java
+++ b/velocity/src/main/java/me/adrianed/authmevelocity/velocity/listener/ProxyListener.java
@@ -25,7 +25,7 @@ public final class ProxyListener {
     @Subscribe
     public EventTask onDisconnect(final DisconnectEvent event) {
         if (event.getLoginStatus() == DisconnectEvent.LoginStatus.CONFLICTING_LOGIN) {
-            return EventTask.async(() -> {});
+            return null;
         }
 
         return EventTask.async(() -> plugin.removePlayer(event.getPlayer()));


### PR DESCRIPTION
This fixes the issue where a colliding login will unlogin a user even though the colliding login did not go through. 
Example:
1. PlayerA logs in and plays server
2. Someone else logs in with username PlayerA, but gets kicked because PlayerA is already playing
3. PlayerA gets outlogged by AuthMeVelocity and can for example not execute commands anymore.

This PR fixes that.