### PR TITLE
feat: Implement Spigot Compatibility

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -10,7 +10,6 @@ repositories {
 
 dependencies {
     compileOnly("org.spongepowered:configurate-hocon:4.1.2")
-    compileOnly("org.slf4j:slf4j-api:2.0.6")
     compileOnly("net.byteflux:libby-core:1.1.5")
     compileOnly("net.kyori:adventure-api:4.12.0")
 }

--- a/common/src/main/java/me/adrianed/authmevelocity/common/configuration/Loader.java
+++ b/common/src/main/java/me/adrianed/authmevelocity/common/configuration/Loader.java
@@ -1,17 +1,15 @@
 package me.adrianed.authmevelocity.common.configuration;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.slf4j.Logger;
-
 import org.spongepowered.configurate.CommentedConfigurationNode;
-import org.spongepowered.configurate.ConfigurateException;
 import org.spongepowered.configurate.hocon.HoconConfigurationLoader;
 
 public final class Loader {
     private Loader() {}
-    public static <C> ConfigurationContainer<C> loadMainConfig(Path path, Class<C> clazz, Logger logger) {
+    public static <C> ConfigurationContainer<C> loadMainConfig(Path path, Class<C> clazz) throws IOException {
         path = path.resolve("config.conf");
         final boolean firstCreation = Files.notExists(path);
         final HoconConfigurationLoader loader = HoconConfigurationLoader.builder()
@@ -24,19 +22,14 @@ public final class Loader {
             .path(path)
             .build();
 
-        final C config;
-        try {
-            final CommentedConfigurationNode node = loader.load();
-            config = node.get(clazz);
-            if (firstCreation) {
-                node.set(clazz, config);
-                loader.save(node);
-            }
-            
-        } catch (ConfigurateException exception){
-            logger.error("Could not load config.conf file", exception);
-            return null;
+
+        final CommentedConfigurationNode node = loader.load();
+        final C config = node.get(clazz);
+        if (firstCreation) {
+            node.set(clazz, config);
+            loader.save(node);
         }
-        return new ConfigurationContainer<>(config, clazz, loader, logger);
+
+        return new ConfigurationContainer<>(config, clazz, loader);
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = me.adrianed.authmevelocity
-version = 3.0.2
+version = 3.0.3-SNAPSHOT
 description = AuthMeReloaded Support for Velocity
 url = https://github.com/4drian3d/AuthMeVelocity
 id = authmevelocity

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 dependencies {
     compileOnly(project(":authmevelocity-common"))
     compileOnly(project(":authmevelocity-api-paper"))
-    compileOnly("io.papermc.paper:paper-api:1.19.1-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.19.3-R0.1-SNAPSHOT")
     compileOnly("fr.xephi:authme:5.6.0-SNAPSHOT")
     compileOnly("com.github.4drian3d:MiniPlaceholders:1.3.1")
     shadow("net.byteflux:libby-bukkit:1.1.5")

--- a/paper/src/main/java/me/adrianed/authmevelocity/paper/listeners/AuthMeListener.java
+++ b/paper/src/main/java/me/adrianed/authmevelocity/paper/listeners/AuthMeListener.java
@@ -10,6 +10,7 @@ import fr.xephi.authme.events.RegisterEvent;
 import fr.xephi.authme.events.UnregisterByAdminEvent;
 import fr.xephi.authme.events.UnregisterByPlayerEvent;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -27,9 +28,13 @@ public final class AuthMeListener implements Listener {
         final Player player = event.getPlayer();
         plugin.logDebug("LoginEvent | Start");
 
-        if (new PreSendLoginEvent(player).callEvent()) {
+        // I hate this, but... Spigot compatibility ¯\_(ツ)_/¯
+        final var preSendLoginEvent = new PreSendLoginEvent(player);
+        Bukkit.getPluginManager().callEvent(preSendLoginEvent);
+
+        if (!preSendLoginEvent.isCancelled()) {
             plugin.sendMessageToProxy(player, MessageType.LOGIN, player.getName());
-            plugin.getSLF4JLogger().info("LoginEvent | PreSendLoginEvent allowed");
+            plugin.getLogger().info("LoginEvent | PreSendLoginEvent allowed");
         }
     }
 

--- a/paper/src/main/java/me/adrianed/authmevelocity/paper/listeners/MessageListener.java
+++ b/paper/src/main/java/me/adrianed/authmevelocity/paper/listeners/MessageListener.java
@@ -3,6 +3,8 @@ package me.adrianed.authmevelocity.paper.listeners;
 import com.google.common.io.ByteArrayDataInput;
 import com.google.common.io.ByteStreams;
 
+import me.adrianed.authmevelocity.common.MessageType;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.messaging.PluginMessageListener;
 import org.jetbrains.annotations.NotNull;
@@ -35,9 +37,9 @@ public class MessageListener implements PluginMessageListener {
         if ("main".equals(subChannel)) {
             plugin.logDebug("PluginMessage | Main Subchannel");
             final String msg = input.readUTF();
-            if ("LOGIN".equals(msg)) {
+            if (MessageType.LOGIN.toString().equals(msg)) {
                 plugin.logDebug("PluginMessage | Login Message");
-                new LoginByProxyEvent(player).callEvent();
+                Bukkit.getPluginManager().callEvent(new LoginByProxyEvent(player));
                 AuthMeApi.getInstance().forceLogin(player);
             }
         }

--- a/velocity/src/main/java/me/adrianed/authmevelocity/velocity/AuthMeVelocityPlugin.java
+++ b/velocity/src/main/java/me/adrianed/authmevelocity/velocity/AuthMeVelocityPlugin.java
@@ -90,7 +90,13 @@ public final class AuthMeVelocityPlugin implements AuthMeVelocityAPI {
                     logger, pluginDirectory, proxy.getPluginManager(), this));
         libraries.loadLibraries();
 
-        this.config = Loader.loadMainConfig(pluginDirectory, ProxyConfiguration.class, logger);
+        try {
+            this.config = Loader.loadMainConfig(pluginDirectory, ProxyConfiguration.class);
+        } catch (Exception e) {
+            logger.error("Could not load config.conf file", e);
+            return;
+        }
+
         logDebug("Loaded plugin libraries");
 
         final int pluginId = 16128;
@@ -105,21 +111,21 @@ public final class AuthMeVelocityPlugin implements AuthMeVelocityAPI {
         ).forEach(listener ->
             proxy.getEventManager().register(this, listener));
 
-        boolean fastlogin = proxy.getPluginManager().isLoaded("fastlogin");
+        final boolean fastlogin = proxy.getPluginManager().isLoaded("fastlogin");
         metrics.addCustomChart(new SimplePie("fastlogin_compatibility", () -> Boolean.toString(fastlogin)));
         if (fastlogin) {
             logDebug("Register FastLogin compatibility");
             proxy.getEventManager().register(this, new FastLoginListener(proxy, this));
         }
 
-        boolean miniplaceholders = proxy.getPluginManager().isLoaded("miniplaceholders");
+        final boolean miniplaceholders = proxy.getPluginManager().isLoaded("miniplaceholders");
         metrics.addCustomChart(new SimplePie("miniplaceholders_compatibility", () -> Boolean.toString(miniplaceholders)));
         if (miniplaceholders) {
             logDebug("Register MiniPlaceholders compatibility");
             AuthMePlaceholders.getExpansion(this).register();
         }
 
-        AuthmeCommand.register(this, proxy.getCommandManager());
+        AuthmeCommand.register(this, proxy.getCommandManager(), logger);
 
         this.sendInfoMessage();
     }

--- a/velocity/src/main/java/me/adrianed/authmevelocity/velocity/commands/AuthmeCommand.java
+++ b/velocity/src/main/java/me/adrianed/authmevelocity/velocity/commands/AuthmeCommand.java
@@ -10,25 +10,28 @@ import com.velocitypowered.api.command.CommandSource;
 
 import me.adrianed.authmevelocity.velocity.AuthMeVelocityPlugin;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.slf4j.Logger;
 
 public class AuthmeCommand {
     private AuthmeCommand() {}
 
-    public static void register(AuthMeVelocityPlugin plugin, CommandManager manager) {
+    public static void register(AuthMeVelocityPlugin plugin, CommandManager manager, Logger logger) {
         LiteralCommandNode<CommandSource> command = LiteralArgumentBuilder.<CommandSource>literal("authmevelocity")
             .requires(src -> src.hasPermission("authmevelocity.commands"))
             .then(LiteralArgumentBuilder.<CommandSource>literal("reload")
                 .executes(cmd -> {
                     CommandSource source = cmd.getSource();
-                    plugin.config().reload().thenAcceptAsync(result -> {
-                        if(result) {
+                    plugin.config().reload().handleAsync((v, ex) -> {
+                        if (ex == null) {
                             plugin.sendInfoMessage();
                             source.sendMessage(MiniMessage.miniMessage().deserialize(
-                                "<aqua>AuthmeVelocity <green>has been successfully reloaded"));
+                                    "<aqua>AuthmeVelocity <green>has been successfully reloaded"));
                         } else {
                             source.sendMessage(MiniMessage.miniMessage().deserialize(
-                                "<dark_red>There was an error while reloading the configuration. <red>Check the server console"));
+                                    "<dark_red>There was an error while reloading the configuration. <red>Check the server console"));
+                            logger.error(ex.getMessage(), ex.getCause());
                         }
+                        return null;
                     });
                     return Command.SINGLE_SUCCESS;
                 })


### PR DESCRIPTION
Some functions of the paper module have been modified, for example:
- Use `getLogger` instead of `getSLF4JLogger`.
- User `PluginManager#callEvent` instead of `Event#callEvent`

To be able to support Spigot 1.8-1.11+

This pull request has not been tested in these environments, so there won't be full support when using them there, but it should work

Also:

- fix: Fixed possible NullPointerException in case the configuration could not be loaded
