### PR TITLE
Update PluginMessageListener.java

### DIFF
--- a/velocity/src/main/java/io/github/_4drian3d/authmevelocity/velocity/listener/data/PluginMessageListener.java
+++ b/velocity/src/main/java/io/github/_4drian3d/authmevelocity/velocity/listener/data/PluginMessageListener.java
@@ -74,7 +74,13 @@ public final class PluginMessageListener implements Listener<PluginMessageEvent>
 
             final ByteArrayDataInput input = event.dataAsDataStream();
             final String message = input.readUTF();
-            final MessageType type = TYPES.valueOrThrow(message.toUpperCase(Locale.ROOT));
+            final MessageType type;
+            try {
+                type = TYPES.valueOrThrow(message.toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException ex) {
+                plugin.logDebug(() -> "PluginMessageEvent | Unknown MessageType: " + message);
+                return;
+            }
             final String name = input.readUTF();
             final Player player = proxy.getPlayer(name).orElse(null);
 


### PR DESCRIPTION
Wrapping the MessageType lookup in a try-catch block ensures that if an attacker sends a malformed or unexpected message string, the code will not throw an unhandled exception. Instead, it gracefully logs the issue and exits the packet handling routine. This prevents potential crashes or disruptions in processing and enhances the plugin's resilience against malicious input.