### PR TITLE
[CRITICAL]: fix authentication bypassing vulnerability

### DIFF
--- a/common/src/main/java/io/github/_4drian3d/authmevelocity/common/configuration/PaperConfiguration.java
+++ b/common/src/main/java/io/github/_4drian3d/authmevelocity/common/configuration/PaperConfiguration.java
@@ -19,6 +19,7 @@ package io.github._4drian3d.authmevelocity.common.configuration;
 
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 import org.spongepowered.configurate.objectmapping.meta.Comment;
+import org.spongepowered.configurate.objectmapping.meta.Setting;
 
 @ConfigSerializable
 public class PaperConfiguration {
@@ -26,5 +27,12 @@ public class PaperConfiguration {
     private boolean debug = false;
     public boolean debug() {
         return this.debug;
+    }
+
+    @Comment("A secret key to encrypt channel messages. Must be the same on either Paper and Velocity side. The proxy will not start if this key is not set just to be safe.")
+    @Setting("secret")
+    private String secret = "changeme";
+    public String secret() {
+        return this.secret;
     }
 }

--- a/common/src/main/java/io/github/_4drian3d/authmevelocity/common/configuration/ProxyConfiguration.java
+++ b/common/src/main/java/io/github/_4drian3d/authmevelocity/common/configuration/ProxyConfiguration.java
@@ -21,6 +21,7 @@ import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 import org.spongepowered.configurate.objectmapping.meta.Comment;
 
 import io.github._4drian3d.authmevelocity.common.enums.SendMode;
+import org.spongepowered.configurate.objectmapping.meta.Setting;
 
 import java.util.List;
 
@@ -32,7 +33,14 @@ public class ProxyConfiguration {
     public List<String> authServers() {
         return this.authServers;
     }
-    
+
+    @Comment("A secret key to encrypt channel messages. Must be the same on either Paper and Velocity side. The proxy will not start if this key is not set just to be safe.")
+    @Setting("secret")
+    private String secret = "changeme";
+    public String secret() {
+        return this.secret;
+    }
+
     private SendOnLogin sendOnLogin = new SendOnLogin();
     public SendOnLogin sendOnLogin() {
         return this.sendOnLogin;

--- a/paper/src/main/java/io/github/_4drian3d/authmevelocity/paper/AuthMeVelocityPlugin.java
+++ b/paper/src/main/java/io/github/_4drian3d/authmevelocity/paper/AuthMeVelocityPlugin.java
@@ -61,6 +61,17 @@ public final class AuthMeVelocityPlugin extends JavaPlugin {
             return;
         }
 
+        // Check if the secret is the default one. If it is, shut down the server to prevent security issues.
+        if(config.get().secret().equals("changeme")) {
+            componentLogger.error("------ AuthMeVelocity ------");
+            componentLogger.error("You must change the secret in the config file!");
+            componentLogger.error("The secret must match with the secret set in AuthMeVelocity!");
+            componentLogger.error("Shutting down server to prevent security issues.");
+            componentLogger.error("------ AuthMeVelocity ------");
+            this.getServer().shutdown();
+            return;
+        }
+
         final var server = this.getServer();
 
         server.getMessenger().registerOutgoingPluginChannel(this, CHANNEL);
@@ -88,6 +99,9 @@ public final class AuthMeVelocityPlugin extends JavaPlugin {
             final @NotNull String playerName
     ) {
         final ByteArrayDataOutput out = ByteStreams.newDataOutput();
+        
+        // Send the secret to the proxy to verify the message
+        out.writeUTF(config.get().secret());
         out.writeUTF(type.toString());
         out.writeUTF(playerName);
 

--- a/velocity/src/main/java/io/github/_4drian3d/authmevelocity/velocity/AuthMeVelocityPlugin.java
+++ b/velocity/src/main/java/io/github/_4drian3d/authmevelocity/velocity/AuthMeVelocityPlugin.java
@@ -127,6 +127,13 @@ public final class AuthMeVelocityPlugin implements AuthMeVelocityAPI {
             return;
         }
 
+        // Check if the secret is still the default one, if not shutdown the proxy to prevent security issues
+        if(config.get().secret().equals("changeme")) {
+            logger.error("Please change the secret in the config file! Shutting down proxy...");
+            proxy.shutdown();
+            return;
+        }
+
         logDebug("Loaded plugin libraries");
 
         final int pluginId = 16128;

--- a/velocity/src/main/java/io/github/_4drian3d/authmevelocity/velocity/listener/data/PluginMessageListener.java
+++ b/velocity/src/main/java/io/github/_4drian3d/authmevelocity/velocity/listener/data/PluginMessageListener.java
@@ -73,10 +73,17 @@ public final class PluginMessageListener implements Listener<PluginMessageEvent>
             }
 
             final ByteArrayDataInput input = event.dataAsDataStream();
+            final String secret = input.readUTF();
             final String message = input.readUTF();
             final MessageType type = TYPES.valueOrThrow(message.toUpperCase(Locale.ROOT));
             final String name = input.readUTF();
             final Player player = proxy.getPlayer(name).orElse(null);
+
+            // Verify the secret sent from Paper
+            if(!plugin.config().get().secret().equals(secret)){
+                logger.error(name + " tried to send a message with an invalid secret provided or the secret is not matching with the secret set on Paper server");
+                return;
+            }
 
             switch (type) {
                 case LOGIN -> {


### PR DESCRIPTION
# Security Fix: Authentication Bypass Exploit in AuthMeVelocity

## How did the exploit work?  
Players using modified clients were able to send a message to AuthMeVelocity’s plugin messaging channel, falsely claiming they had successfully logged in. As a result, they could bypass authentication entirely.  

## How did I fix this critical bug?  
I introduced a configurable **secret** field on both the Velocity and Paper sides. Every time a message is sent from Paper to Velocity, it includes this secret. Upon receiving the message, Velocity verifies whether the provided secret matches the one stored in its configuration. If the secrets do not match, Velocity takes no action, preventing unauthorized logins.  

### Mandatory secret configuration  
To ensure server owners properly configure the secret, I implemented a safeguard:  
- On the first startup, the plugin sets the default secret to **"changeme"** in the configuration files of both Velocity and Paper.  
- If the secret remains unchanged and is still **"changeme"**, the plugin will:  
  - **Shut down the proxy on Velocity**  
  - **Stop the server on Paper**  
- This prevents server owners from unknowingly using the default value, which could otherwise be exploited by attackers simply sending `"changeme"` as the authentication key.  
- This enforcement ensures that every server owner sets a unique secret, improving overall security.  

### Improved config handling (Backward Compatibility)  
- Previously, the secret field was only written to the config if the entire file was deleted.  
- Now, if the secret field is missing (e.g., for users updating from an older version), it will be **automatically added** to the config without requiring a full reset.  
